### PR TITLE
Add support for data proxy

### DIFF
--- a/dvc_webhdfs/__init__.py
+++ b/dvc_webhdfs/__init__.py
@@ -49,6 +49,17 @@ class WebHDFSFileSystem(FileSystem):
     def fs(self):
         from fsspec.implementations.webhdfs import WebHDFS
 
+        # If target data_proxy provided construct the source from host/port
+        if "data_proxy_target" in self.fs_args:
+            host = self.fs_args["host"]
+            port = self.fs_args["port"]
+
+            protocol = "https" if self.fs_args.get("use_https") else "http"
+
+            self.fs_args["data_proxy"] = {
+                f"{protocol}://{host}:{port}/webhdfs/v1":self.fs_args["data_proxy_target"]
+            }
+
         fs = WebHDFS(**self.fs_args)
         fs.session.verify = self._ssl_verify
         return fs

--- a/dvc_webhdfs/__init__.py
+++ b/dvc_webhdfs/__init__.py
@@ -56,8 +56,9 @@ class WebHDFSFileSystem(FileSystem):
 
             protocol = "https" if self.fs_args.get("use_https") else "http"
 
+            source_url = f"{protocol}://{host}:{port}/webhdfs/v1"
             self.fs_args["data_proxy"] = {
-                f"{protocol}://{host}:{port}/webhdfs/v1":self.fs_args["data_proxy_target"]
+                source_url: self.fs_args["data_proxy_target"]
             }
 
         fs = WebHDFS(**self.fs_args)


### PR DESCRIPTION
If the edgenode is behind a High Availability Proxy, the problem is that this proxy might require a rewrite of the original url.

For example, if the hostname is `clusterhost` and the port is 8443, the normal address used by webhdfs API endpoint is:
`https://clusterhost:8443/webhdfs/v1`.

In the case of a HA proxy, this might require the following URL:
`https://clusterhost:8443/gateway/cluster/webhdfs/v1`

The webhdfs fsspec has support for a `data_proxy` parameter that allows you to either provide a callable or a dictionary with find/replace values.

After a quick discussion on the DVC discord, opted to assume the source url for this find/replace dictionary will always be constructed from the url provided, the protocol provided and the hardcoded suffix `/webhdfs/v1`. Therefore, the user will only have to provide the target part of the rewrite (in the example above `https://clusterhost:443/gateway/cluster/webhdfs/v1`) to ensure every occurence of `https://clusterhost:8443/webhdfs/v1` will be rewritten to `https://clusterhost:443/gateway/cluster/webhdfs/v1`

I am not sure what kind of additional unit tests would be useful for this (since I also don't see any unit tests with regards to the ssl_verify parameter).

I tested this code in combination with a patched version of DVC (add `user` and `data_proxy_target` parameters to the config_schema.json to support the parameters in DVC config) with the version of fsspec that has my recent PR for supporting basic authentication (https://github.com/fsspec/filesystem_spec/pull/1409) and this has been running without any problems.

Related PRs:
* PR to update documentation https://github.com/iterative/dvc.org/pull/4980
* PR for required modifications in schema support DVC https://github.com/iterative/dvc/pull/10075